### PR TITLE
Change structure deploy script.

### DIFF
--- a/scripts/pantheon/deploy
+++ b/scripts/pantheon/deploy
@@ -26,7 +26,7 @@ echo "Deleting old Multidevs for Closed PRs. Sending to Background."
 
 # Prepare for Pantheon
 echo "Preparing Artifact for Pantheon."
-terminus -n build:getignore:cut $TERMINUS_SITE
+terminus -n build:gitignore:cut $TERMINUS_SITE
 
 echo "Building from $CI_BRANCH."
 echo "The Main Branch is $MAIN_BRANCH."

--- a/scripts/pantheon/deploy
+++ b/scripts/pantheon/deploy
@@ -26,7 +26,7 @@ echo "Deleting old Multidevs for Closed PRs. Sending to Background."
 
 # Prepare for Pantheon
 echo "Preparing Artifact for Pantheon."
-composer -n run prepare-for-pantheon
+terminus -n build:getignore:cut $TERMINUS_SITE
 
 echo "Building from $CI_BRANCH."
 echo "The Main Branch is $MAIN_BRANCH."

--- a/scripts/pantheon/deploy
+++ b/scripts/pantheon/deploy
@@ -26,7 +26,7 @@ echo "Deleting old Multidevs for Closed PRs. Sending to Background."
 
 # Prepare for Pantheon
 echo "Preparing Artifact for Pantheon."
-terminus -n build:gitignore:cut $TERMINUS_SITE
+terminus -n build:gitignore:cut
 
 echo "Building from $CI_BRANCH."
 echo "The Main Branch is $MAIN_BRANCH."


### PR DESCRIPTION
when project ci calls the deploy script specifically the deploy-to-pantheon step the script `composer -n run prepare-for-pantheon` is called but the script it calls is not found by default in drupal core, with the change to 'terminus -n build:gitignore:cut' we remove that 'dependency'